### PR TITLE
Don't pre-render extra YAMLs

### DIFF
--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -6,5 +6,5 @@ local argocd = import 'lib/argocd.libjsonnet';
 local app = argocd.App('minio', params.namespace, secrets=true);
 
 {
-  'minio': app,
+  minio: app,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -17,5 +17,5 @@ local params = inv.parameters.minio;
     },
   },
   namespace: kube.Namespace(params.namespace),
-  "extraYAMLs": std.manifestYamlDoc(params.extraYAMLs),
+  extraYAMLs: params.extraYAMLs,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,7 +7,7 @@ local params = inv.parameters.minio;
 
 // Define outputs below
 {
-  "minio-credentials": kube.Secret(params.helmValues.existingSecret) {
+  'minio-credentials': kube.Secret(params.helmValues.existingSecret) {
     stringData: {
       accesskey: params.minioCredentialsSecret.accesskey,
       secretkey: params.minioCredentialsSecret.secretkey,


### PR DESCRIPTION
The value for each output key is intended to be an object or list of
objects, and not a string. Pre-rendering the output as YAML will result
in the already rendered YAML being rendered again, as a string is also a
valid list.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
